### PR TITLE
Change fields in ouput of pool stats

### DIFF
--- a/plugins/ceph_pool_plugin.py
+++ b/plugins/ceph_pool_plugin.py
@@ -83,9 +83,9 @@ class CephPoolPlugin(base.Base):
 
         # push totals from df
         data[ceph_cluster]['cluster'] = {}
-        data[ceph_cluster]['cluster']['total_space'] = int(json_df_data['stats']['total_space']) * 1024.0
-        data[ceph_cluster]['cluster']['total_used'] = int(json_df_data['stats']['total_used']) * 1024.0
-        data[ceph_cluster]['cluster']['total_avail'] = int(json_df_data['stats']['total_avail']) * 1024.0
+        data[ceph_cluster]['cluster']['total_space'] = int(json_df_data['stats']['total_bytes'])
+        data[ceph_cluster]['cluster']['total_used'] = int(json_df_data['stats']['total_used_bytes'])
+        data[ceph_cluster]['cluster']['total_avail'] = int(json_df_data['stats']['total_avail_bytes'])
 
         return data
 


### PR DESCRIPTION
In Ceph Giant version, the total_space, total_used, and total_avail
fields in the JSON dumps for pool stats are replaced with
total_bytes, total_used_bytes, and total_avail_bytes fields.
